### PR TITLE
Add Jest and price tests

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    '@babel/preset-react'
+  ]
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[jt]sx?$': 'babel-jest'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "cross-env NODE_ENV=production next build",
     "start": "next start",
     "lint": "next lint",
-    "deploy": "next build && gh-pages -d out"
+    "deploy": "next build && gh-pages -d out",
+    "test": "jest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.8",
@@ -19,6 +20,11 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "gh-pages": "^6.3.0"
+    "gh-pages": "^6.3.0",
+    "jest": "^29.7.0",
+    "babel-jest": "^29.7.0",
+    "@babel/core": "^7.23.3",
+    "@babel/preset-env": "^7.23.3",
+    "@babel/preset-react": "^7.22.5"
   }
 }

--- a/tests/calculatePrice.test.js
+++ b/tests/calculatePrice.test.js
@@ -1,0 +1,44 @@
+import { calculatePrice } from '../src/utils/calculatePrice';
+
+describe('calculatePrice', () => {
+  test('base pricing with default options', () => {
+    const result = calculatePrice({
+      model: 'rwd',
+      color: 'stealthGrey',
+      wheel: 'crossflow19',
+      interior: 'allBlack',
+      region: 'none',
+      autopilot: 'none',
+      registrationMethod: 'self',
+      deliveryOption: 'self',
+      regions: []
+    });
+
+    expect(result.basePrice).toBe(52990000);
+    expect(result.colorPrice).toBe(0);
+    expect(result.wheelPrice).toBe(0);
+    expect(result.carTotalPrice).toBe(53116500);
+    expect(result.total).toBe(53116500);
+  });
+
+  test('pricing with subsidy and child benefit', () => {
+    const regions = [{ key: 'seoul', rwd: 3000000, longrange: 2000000 }];
+    const result = calculatePrice({
+      model: 'longrange',
+      color: 'ultraRed',
+      wheel: 'induction20',
+      interior: 'blackWhite',
+      region: 'seoul',
+      autopilot: 'eap',
+      registrationMethod: 'agency',
+      deliveryOption: 'request',
+      childCount: 3,
+      regions
+    });
+
+    expect(result.subsidy).toBe(2000000);
+    expect(result.childBenefit).toBe(2000000);
+    expect(result.carTotalPrice).toBe(74530000);
+    expect(result.total).toBe(70530000);
+  });
+});


### PR DESCRIPTION
## Summary
- setup Jest with Babel
- add test script to `package.json`
- add unit tests for `calculatePrice`

## Testing
- `npm test` *(fails: jest not found)*